### PR TITLE
Improved Expansion cache invalidation based on Remote Config

### DIFF
--- a/app/src/main/java/com/r0adkll/deckbuilder/DeckApp.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/DeckApp.kt
@@ -3,6 +3,8 @@ package com.r0adkll.deckbuilder
 
 import android.app.Application
 import com.bumptech.glide.request.target.ViewTarget
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreSettings
 import com.r0adkll.deckbuilder.internal.AppDelegate
 import com.r0adkll.deckbuilder.internal.analytics.Analytics
 import com.r0adkll.deckbuilder.internal.analytics.LoggingAnalyticInterface
@@ -29,6 +31,7 @@ class DeckApp : Application() {
         installDagger().inject(this)
         installAnalytics()
         installDelegates()
+        installFirestore()
 
         // Setup Glide to allow for custom tag id's so we can set tags to images for our own purpose
         ViewTarget.setTagId(R.id.glide_tag_id)
@@ -47,6 +50,15 @@ class DeckApp : Application() {
 
     fun installLeakCanary() {
         refWatcher = LeakCanary.install(this)
+    }
+
+
+    fun installFirestore() {
+        val firestore = FirebaseFirestore.getInstance()
+        val settings = FirebaseFirestoreSettings.Builder()
+                .setTimestampsInSnapshotsEnabled(true)
+                .build()
+        firestore.firestoreSettings = settings
     }
 
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/AppPreferences.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/AppPreferences.kt
@@ -19,6 +19,7 @@ class AppPreferences @Inject constructor(
         const val KEY_ONBOARDING = "pref_onboarding"
         const val KEY_QUICKSTART = "pref_quickstart"
         const val KEY_EXPANSIONS = "pref_expansions_sm7" // Bump name to HARD force people to the new expansion
+        const val KEY_EXPANSIONS_VERSION = "pref_expansions_version"
         const val KEY_DEFAULT_ENERGY_SET = "pref_default_energy_set"
         const val KEY_PLAYER_NAME = "pref_player_name"
         const val KEY_PLAYER_ID = "pref_player_id"
@@ -38,6 +39,7 @@ class AppPreferences @Inject constructor(
     var lastVersion by IntPreference(KEY_LAST_VERSION, -1)
     var deviceId by StringPreference(KEY_DEVICE_ID)
     var offlineEnabled by BooleanPreference(KEY_OFFLINE_ENABLED, false)
+    var expansionsVersion by IntPreference(KEY_EXPANSIONS_VERSION, 1)
 
     val expansions by ReactiveExpansionsPreference(KEY_EXPANSIONS)
     val basicEnergySet by ReactiveBasicEnergySetPreference(KEY_DEFAULT_ENERGY_SET)

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/DataModule.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/DataModule.kt
@@ -10,10 +10,10 @@ import com.r0adkll.deckbuilder.arch.data.features.cards.DefaultCacheManager
 import com.r0adkll.deckbuilder.arch.data.features.cards.cache.CardCache
 import com.r0adkll.deckbuilder.arch.data.features.cards.cache.RequeryCardCache
 import com.r0adkll.deckbuilder.arch.data.features.cards.repository.DefaultCardRepository
-import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.CachingCardDataSource
-import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.CardDataSource
-import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.search.CombinedSearchDataSource
-import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.search.SearchDataSource
+import com.r0adkll.deckbuilder.arch.data.features.expansions.CachingExpansionDataSource
+import com.r0adkll.deckbuilder.arch.data.features.expansions.ExpansionDataSource
+import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.CombinedSearchDataSource
+import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.SearchDataSource
 import com.r0adkll.deckbuilder.arch.data.features.decks.cache.DeckCache
 import com.r0adkll.deckbuilder.arch.data.features.decks.cache.FirestoreDeckCache
 import com.r0adkll.deckbuilder.arch.data.features.decks.repository.DefaultDeckRepository
@@ -50,9 +50,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.requery.Persistable
 import io.requery.android.sqlite.DatabaseSource
 import io.requery.reactivex.KotlinReactiveEntityStore
-import io.requery.sql.KotlinConfiguration
 import io.requery.sql.KotlinEntityDataStore
-import okhttp3.logging.HttpLoggingInterceptor.Level.HEADERS
 import okhttp3.logging.HttpLoggingInterceptor.Level.BODY
 import okhttp3.logging.HttpLoggingInterceptor.Level.NONE
 import java.util.concurrent.Executors
@@ -132,7 +130,7 @@ class DataModule {
      */
 
     @Provides @AppScope
-    fun provideCardDataSource(dataSource: CachingCardDataSource): CardDataSource = dataSource
+    fun provideExpansionDataSource(dataSource: CachingExpansionDataSource): ExpansionDataSource = dataSource
 
 
     @Provides @AppScope

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/DataModule.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/DataModule.kt
@@ -29,6 +29,8 @@ import com.r0adkll.deckbuilder.arch.data.features.validation.model.DuplicateRule
 import com.r0adkll.deckbuilder.arch.data.features.validation.model.PrismStarRule
 import com.r0adkll.deckbuilder.arch.data.features.validation.model.SizeRule
 import com.r0adkll.deckbuilder.arch.data.features.validation.repository.DefaultDeckValidator
+import com.r0adkll.deckbuilder.arch.data.remote.plugin.CacheInvalidatePlugin
+import com.r0adkll.deckbuilder.arch.data.remote.plugin.RemotePlugin
 import com.r0adkll.deckbuilder.arch.domain.features.cards.CacheManager
 import com.r0adkll.deckbuilder.arch.domain.features.cards.repository.CardRepository
 import com.r0adkll.deckbuilder.arch.domain.features.decks.repository.DeckRepository
@@ -44,6 +46,7 @@ import com.r0adkll.deckbuilder.util.Schedulers
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.ElementsIntoSet
+import dagger.multibindings.IntoSet
 import io.pokemontcg.Config
 import io.pokemontcg.Pokemon
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -58,6 +61,10 @@ import java.util.concurrent.Executors
 
 @Module
 class DataModule {
+
+    @Provides @AppScope @IntoSet
+    fun provideCacheInvalidatePlugin(plugin: CacheInvalidatePlugin): RemotePlugin = plugin
+
 
     @Provides @AppScope
     fun provideSharedPreferences(context: Context): SharedPreferences {

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/Remote.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/Remote.kt
@@ -10,6 +10,7 @@ import com.jakewharton.rxrelay2.PublishRelay
 import com.jakewharton.rxrelay2.Relay
 import com.r0adkll.deckbuilder.BuildConfig
 import com.r0adkll.deckbuilder.R
+import com.r0adkll.deckbuilder.arch.data.features.expansions.model.ExpansionVersion
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.SearchProxies
 import io.reactivex.Observable
 import timber.log.Timber
@@ -39,7 +40,7 @@ class Remote @Inject constructor() {
      * - version_code represents the version of the data that may change unrelated to new expansions (i.e. rotation legality changes)
      * - expansion_code represents the latest available expansion in the set (i.e. sm7 - Celestial Storm) which can indicate if a new expansion was added
      */
-    val expansionVersion by RemoteString(KEY_EXPANSION_VERSION)
+    val expansionVersion by RemoteObject(KEY_EXPANSION_VERSION, ExpansionVersion::class)
 
 
     /**

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/Remote.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/Remote.kt
@@ -30,7 +30,7 @@ class Remote @Inject constructor() {
 
 
     /**
-     * This is a list of search proxy/aliases that better improve the search expierence for the user
+     * This is a list of search proxy/aliases that better improve the search experience for the user
      */
     val searchProxies by RemoteObject(KEY_SEARCH_PROXIES, SearchProxies::class)
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/Remote.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/Remote.kt
@@ -60,6 +60,7 @@ class Remote @Inject constructor() {
      * remote configuration settings if needed
      */
     fun check() {
+        Timber.d("Checking remote config values...")
 
         // Configure
         val settings = FirebaseRemoteConfigSettings.Builder()
@@ -74,6 +75,8 @@ class Remote @Inject constructor() {
         remote.fetch(cacheExpiration)
                 .addOnCompleteListener {
                     Timber.i("Remote Config values fetched. Activating!")
+                    Timber.i("> Expansion Version: $expansionVersion")
+                    Timber.i("> Search Proxies: $searchProxies")
                     remote.activateFetched()
                     remoteFetchRelay.accept(this@Remote)
                 }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/Remote.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/Remote.kt
@@ -26,14 +26,6 @@ import kotlin.reflect.KProperty
 class Remote @Inject constructor() {
 
     /**
-     * The the set code for the latest expansion in the API. This field is used to invalidate the
-     * set/expansion cache in the event of when new set's get added without having to ship an app
-     * update or poll the API.
-     */
-    val latestExpansion by RemoteString(KEY_LATEST_EXPANSION)
-
-
-    /**
      * This is the versioning string for the latest expansion set offered by the api. It's format as
      * follows: <version_code>.<expansion_code> e.g. 1.sm7
      *
@@ -127,7 +119,6 @@ class Remote @Inject constructor() {
 
     companion object {
         private const val KEY_EXPANSION_VERSION = "expansion_version"
-        private const val KEY_LATEST_EXPANSION = "latest_expansion"
         private const val KEY_SEARCH_PROXIES = "search_proxies"
 
         private const val CACHE_EXPIRATION = 3600L

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/cache/RequeryCardCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/cache/RequeryCardCache.kt
@@ -1,7 +1,7 @@
 package com.r0adkll.deckbuilder.arch.data.features.cards.cache
 
 
-import com.r0adkll.deckbuilder.arch.data.Remote
+import com.r0adkll.deckbuilder.arch.data.remote.Remote
 import com.r0adkll.deckbuilder.arch.data.database.entities.AttackEntity
 import com.r0adkll.deckbuilder.arch.data.database.entities.CardEntity
 import com.r0adkll.deckbuilder.arch.data.database.entities.ICardEntity

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/cache/RequeryCardCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/cache/RequeryCardCache.kt
@@ -6,7 +6,7 @@ import com.r0adkll.deckbuilder.arch.data.database.entities.AttackEntity
 import com.r0adkll.deckbuilder.arch.data.database.entities.CardEntity
 import com.r0adkll.deckbuilder.arch.data.database.entities.ICardEntity
 import com.r0adkll.deckbuilder.arch.data.database.mapping.EntityMapper
-import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.CardDataSource
+import com.r0adkll.deckbuilder.arch.data.features.expansions.ExpansionDataSource
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Filter
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.PokemonCard
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.SearchField
@@ -23,7 +23,7 @@ import javax.inject.Inject
 
 class RequeryCardCache @Inject constructor(
         val db: KotlinReactiveEntityStore<Persistable>,
-        val cache: CardDataSource,
+        val cache: ExpansionDataSource,
         val remote: Remote
 ) : CardCache {
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/DefaultCardRepository.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/DefaultCardRepository.kt
@@ -23,6 +23,11 @@ class DefaultCardRepository @Inject constructor(
     }
 
 
+    override fun refreshExpansions(): Observable<List<Expansion>> {
+        return dataSource.refreshExpansions()
+    }
+
+
     override fun search(type: SuperType?, text: String, filter: Filter?): Observable<List<PokemonCard>> {
         return searchDataSource.search(type, text, filter)
     }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/DefaultCardRepository.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/DefaultCardRepository.kt
@@ -1,8 +1,8 @@
 package com.r0adkll.deckbuilder.arch.data.features.cards.repository
 
 
-import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.CardDataSource
-import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.search.SearchDataSource
+import com.r0adkll.deckbuilder.arch.data.features.expansions.ExpansionDataSource
+import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.SearchDataSource
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Filter
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.PokemonCard
@@ -14,7 +14,7 @@ import javax.inject.Inject
 
 
 class DefaultCardRepository @Inject constructor(
-        val dataSource: CardDataSource,
+        val dataSource: ExpansionDataSource,
         val searchDataSource: SearchDataSource
 ) : CardRepository {
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/CachingCardDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/CachingCardDataSource.kt
@@ -34,6 +34,13 @@ class CachingCardDataSource @Inject constructor(
     }
 
 
+    override fun refreshExpansions(): Observable<List<Expansion>> {
+        // Force a refresh from the network, that will subsequently update cache implementations,
+        // but won't clear on failure
+        return network()
+    }
+
+
     private fun network(): Observable<List<Expansion>> {
         return api.set()
                 .observeAll()

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/CardDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/CardDataSource.kt
@@ -8,4 +8,5 @@ import io.reactivex.Observable
 interface CardDataSource {
 
     fun getExpansions(): Observable<List<Expansion>>
+    fun refreshExpansions(): Observable<List<Expansion>>
 }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/CombinedSearchDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/CombinedSearchDataSource.kt
@@ -1,8 +1,8 @@
-package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.search
+package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source
 
 import com.r0adkll.deckbuilder.arch.data.Remote
 import com.r0adkll.deckbuilder.arch.data.features.cards.cache.CardCache
-import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.CardDataSource
+import com.r0adkll.deckbuilder.arch.data.features.expansions.ExpansionDataSource
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Filter
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.PokemonCard
 import com.r0adkll.deckbuilder.util.Schedulers
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class CombinedSearchDataSource @Inject constructor(
         val api: Pokemon,
         val cache: CardCache,
-        val source: CardDataSource, // FIXME: I should probably come up with better naming/abstractions
+        val source: ExpansionDataSource, // FIXME: I should probably come up with better naming/abstractions
         val remote: Remote,
         val schedulers: Schedulers
 ) : SearchDataSource {

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/CombinedSearchDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/CombinedSearchDataSource.kt
@@ -1,6 +1,6 @@
 package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source
 
-import com.r0adkll.deckbuilder.arch.data.Remote
+import com.r0adkll.deckbuilder.arch.data.remote.Remote
 import com.r0adkll.deckbuilder.arch.data.features.cards.cache.CardCache
 import com.r0adkll.deckbuilder.arch.data.features.expansions.ExpansionDataSource
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Filter

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/DiskSearchDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/DiskSearchDataSource.kt
@@ -1,4 +1,4 @@
-package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.search
+package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source
 
 
 import com.r0adkll.deckbuilder.arch.data.features.cards.cache.CardCache

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/NetworkSearchDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/NetworkSearchDataSource.kt
@@ -1,7 +1,7 @@
 package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source
 
 
-import com.r0adkll.deckbuilder.arch.data.Remote
+import com.r0adkll.deckbuilder.arch.data.remote.Remote
 import com.r0adkll.deckbuilder.arch.data.features.expansions.ExpansionDataSource
 import com.r0adkll.deckbuilder.arch.data.mappings.CardMapper
 import com.r0adkll.deckbuilder.arch.data.mappings.FilterMapper

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/NetworkSearchDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/NetworkSearchDataSource.kt
@@ -1,8 +1,8 @@
-package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.search
+package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source
 
 
 import com.r0adkll.deckbuilder.arch.data.Remote
-import com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.CardDataSource
+import com.r0adkll.deckbuilder.arch.data.features.expansions.ExpansionDataSource
 import com.r0adkll.deckbuilder.arch.data.mappings.CardMapper
 import com.r0adkll.deckbuilder.arch.data.mappings.FilterMapper
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion
@@ -15,14 +15,12 @@ import io.pokemontcg.model.Card
 import io.pokemontcg.model.SuperType
 import io.pokemontcg.requests.CardQueryBuilder
 import io.reactivex.Observable
-import io.reactivex.functions.BiFunction
-import timber.log.Timber
 
 
 @Suppress("UNCHECKED_CAST")
 class NetworkSearchDataSource(
         val api: Pokemon,
-        val source: CardDataSource,
+        val source: ExpansionDataSource,
         val remote: Remote,
         val schedulers: Schedulers
 ) : SearchDataSource {

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/SearchDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/cards/repository/source/SearchDataSource.kt
@@ -1,4 +1,4 @@
-package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source.search
+package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source
 
 
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Filter

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/decks/mapper/EntityMapper.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/decks/mapper/EntityMapper.kt
@@ -107,7 +107,7 @@ object EntityMapper {
                 expansion.expandedLegal,
                 expansion.releaseDate,
                 expansion.symbolUrl,
-                "" // FIXME: Replace this once SDK has been updated
+                expansion.logoUrl
         )
     }
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/CachingExpansionDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/CachingExpansionDataSource.kt
@@ -30,9 +30,13 @@ class CachingExpansionDataSource @Inject constructor(
 
     init {
         // Subscribe to any changes in the remote status and detect if we need to clear expansion cache
+        Timber.i("Subscribing to remote changes")
         remote.observeChanges()
+                .doOnNext { Timber.d("Remote Changed: $it") }
                 .subscribe {
                     it.expansionVersion?.let { (versionCode, expansionCode) ->
+                        Timber.d("Checking Expansion Cache (version: $versionCode, expansion: $expansionCode, prefVersion: ${preferences.expansionsVersion})")
+
                         val invalidCache = memoryCache.getExpansions().blockingFirst().none { it.code == expansionCode } ||
                                 diskCache.getExpansions().blockingFirst().none { it.code == expansionCode }
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/CachingExpansionDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/CachingExpansionDataSource.kt
@@ -1,30 +1,52 @@
-package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source
+package com.r0adkll.deckbuilder.arch.data.features.expansions
 
 
+import android.annotation.SuppressLint
 import com.r0adkll.deckbuilder.arch.data.AppPreferences
 import com.r0adkll.deckbuilder.arch.data.Remote
-import com.r0adkll.deckbuilder.arch.data.features.cards.cache.ExpansionCache
-import com.r0adkll.deckbuilder.arch.data.features.cards.cache.InMemoryExpansionCache
-import com.r0adkll.deckbuilder.arch.data.features.cards.cache.PreferenceExpansionCache
+import com.r0adkll.deckbuilder.arch.data.features.expansions.cache.ExpansionCache
+import com.r0adkll.deckbuilder.arch.data.features.expansions.cache.InMemoryExpansionCache
+import com.r0adkll.deckbuilder.arch.data.features.expansions.cache.PreferenceExpansionCache
 import com.r0adkll.deckbuilder.arch.data.mappings.SetMapper
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion
 import com.r0adkll.deckbuilder.util.Schedulers
 import io.pokemontcg.Pokemon
 import io.reactivex.Observable
 import timber.log.Timber
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
-
-class CachingCardDataSource @Inject constructor(
+@SuppressLint("CheckResult")
+class CachingExpansionDataSource @Inject constructor(
         val api: Pokemon,
         val preferences: AppPreferences,
         val schedulers: Schedulers,
         remote: Remote
-) : CardDataSource {
+) : ExpansionDataSource {
 
     private val memoryCache: ExpansionCache = InMemoryExpansionCache(remote)
     private val diskCache: ExpansionCache = PreferenceExpansionCache(preferences, remote)
+
+
+
+    init {
+        // Subscribe to any changes in the remote status and detect if we need to clear expansion cache
+        remote.observeChanges()
+                .subscribe {
+                    val version = it.expansionVersion.split(".")
+                    if (version.size == 2) {
+                        val versionCode = version[0].toIntOrNull() ?: 1
+                        val expansionCode = version[1]
+
+                        val invalidCache = memoryCache.getExpansions().blockingFirst().none { it.code == expansionCode } ||
+                                diskCache.getExpansions().blockingFirst().none { it.code == expansionCode }
+                        if (versionCode > preferences.expansionsVersion || invalidCache) {
+                            clearExpansions()
+                            preferences.expansionsVersion = versionCode
+                            Timber.i("Expansion Cache Invalidated (version: $versionCode, expansion: $expansionCode)")
+                        }
+                    }
+                }
+    }
 
 
     override fun getExpansions(): Observable<List<Expansion>> {
@@ -38,6 +60,12 @@ class CachingCardDataSource @Inject constructor(
         // Force a refresh from the network, that will subsequently update cache implementations,
         // but won't clear on failure
         return network()
+    }
+
+
+    override fun clearExpansions() {
+        memoryCache.clear()
+        diskCache.clear()
     }
 
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/CachingExpansionDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/CachingExpansionDataSource.kt
@@ -32,13 +32,10 @@ class CachingExpansionDataSource @Inject constructor(
         // Subscribe to any changes in the remote status and detect if we need to clear expansion cache
         remote.observeChanges()
                 .subscribe {
-                    val version = it.expansionVersion.split(".")
-                    if (version.size == 2) {
-                        val versionCode = version[0].toIntOrNull() ?: 1
-                        val expansionCode = version[1]
-
+                    it.expansionVersion?.let { (versionCode, expansionCode) ->
                         val invalidCache = memoryCache.getExpansions().blockingFirst().none { it.code == expansionCode } ||
                                 diskCache.getExpansions().blockingFirst().none { it.code == expansionCode }
+
                         if (versionCode > preferences.expansionsVersion || invalidCache) {
                             clearExpansions()
                             preferences.expansionsVersion = versionCode

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/ExpansionDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/ExpansionDataSource.kt
@@ -1,13 +1,15 @@
 package com.r0adkll.deckbuilder.arch.data.features.expansions
 
 
+import com.r0adkll.deckbuilder.arch.data.features.expansions.cache.ExpansionCache
+import com.r0adkll.deckbuilder.arch.data.features.expansions.cache.ExpansionCache.*
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion
 import io.reactivex.Observable
 
 
 interface ExpansionDataSource {
 
-    fun getExpansions(): Observable<List<Expansion>>
+    fun getExpansions(source: Source = Source.ALL): Observable<List<Expansion>>
     fun refreshExpansions(): Observable<List<Expansion>>
     fun clearExpansions()
 }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/ExpansionDataSource.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/ExpansionDataSource.kt
@@ -1,12 +1,13 @@
-package com.r0adkll.deckbuilder.arch.data.features.cards.repository.source
+package com.r0adkll.deckbuilder.arch.data.features.expansions
 
 
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion
 import io.reactivex.Observable
 
 
-interface CardDataSource {
+interface ExpansionDataSource {
 
     fun getExpansions(): Observable<List<Expansion>>
     fun refreshExpansions(): Observable<List<Expansion>>
+    fun clearExpansions()
 }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/ExpansionCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/ExpansionCache.kt
@@ -1,4 +1,4 @@
-package com.r0adkll.deckbuilder.arch.data.features.cards.cache
+package com.r0adkll.deckbuilder.arch.data.features.expansions.cache
 
 
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/ExpansionCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/ExpansionCache.kt
@@ -10,4 +10,13 @@ interface ExpansionCache {
     fun putExpansions(expansions: List<Expansion>)
     fun getExpansions(): Observable<List<Expansion>>
     fun clear()
+
+    /**
+     * Details the source from which you wish to grab the expansions
+     */
+    enum class Source {
+        ALL,
+        LOCAL,
+        NETWORK
+    }
 }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/InMemoryExpansionCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/InMemoryExpansionCache.kt
@@ -27,7 +27,7 @@ class InMemoryExpansionCache(
 
     override fun getExpansions(): Observable<List<Expansion>> {
         return synchronized(this) {
-            if (expansions.none { it.code == remote.latestExpansion }) {
+            if (expansions.none { it.code == remote.expansionVersion?.expansionCode }) {
                 expansions.clear()
             }
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/InMemoryExpansionCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/InMemoryExpansionCache.kt
@@ -1,7 +1,6 @@
 package com.r0adkll.deckbuilder.arch.data.features.expansions.cache
 
 
-import com.r0adkll.deckbuilder.arch.data.Remote
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion
 import io.reactivex.Observable
 
@@ -10,9 +9,7 @@ import io.reactivex.Observable
  * In Memory implementation of [Expansion] cache to store a list of
  * expansions loaded from API in memory so we don't have to keep requesting it
  */
-class InMemoryExpansionCache(
-        val remote: Remote
-) : ExpansionCache {
+class InMemoryExpansionCache : ExpansionCache {
 
     private val expansions: ArrayList<Expansion> = ArrayList()
 
@@ -27,10 +24,6 @@ class InMemoryExpansionCache(
 
     override fun getExpansions(): Observable<List<Expansion>> {
         return synchronized(this) {
-            if (expansions.none { it.code == remote.expansionVersion?.expansionCode }) {
-                expansions.clear()
-            }
-
             Observable.just(expansions.toList())
         }
     }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/InMemoryExpansionCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/InMemoryExpansionCache.kt
@@ -1,4 +1,4 @@
-package com.r0adkll.deckbuilder.arch.data.features.cards.cache
+package com.r0adkll.deckbuilder.arch.data.features.expansions.cache
 
 
 import com.r0adkll.deckbuilder.arch.data.Remote

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/PreferenceExpansionCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/PreferenceExpansionCache.kt
@@ -19,7 +19,7 @@ class PreferenceExpansionCache(
 
     override fun getExpansions(): Observable<List<Expansion>> {
         // Check to see if we have the latest expansion as per the remote config
-        if (preferences.expansions.get().none { it.code == remote.latestExpansion }) {
+        if (preferences.expansions.get().none { it.code == remote.expansionVersion?.expansionCode }) {
             preferences.expansions.delete()
         }
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/PreferenceExpansionCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/PreferenceExpansionCache.kt
@@ -1,4 +1,4 @@
-package com.r0adkll.deckbuilder.arch.data.features.cards.cache
+package com.r0adkll.deckbuilder.arch.data.features.expansions.cache
 
 
 import com.r0adkll.deckbuilder.arch.data.AppPreferences

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/PreferenceExpansionCache.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/cache/PreferenceExpansionCache.kt
@@ -2,14 +2,13 @@ package com.r0adkll.deckbuilder.arch.data.features.expansions.cache
 
 
 import com.r0adkll.deckbuilder.arch.data.AppPreferences
-import com.r0adkll.deckbuilder.arch.data.Remote
+import com.r0adkll.deckbuilder.arch.data.remote.Remote
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion
 import io.reactivex.Observable
 
 
 class PreferenceExpansionCache(
-        val preferences: AppPreferences,
-        val remote: Remote
+        val preferences: AppPreferences
 ) : ExpansionCache {
 
     override fun putExpansions(expansions: List<Expansion>) {
@@ -18,11 +17,6 @@ class PreferenceExpansionCache(
 
 
     override fun getExpansions(): Observable<List<Expansion>> {
-        // Check to see if we have the latest expansion as per the remote config
-        if (preferences.expansions.get().none { it.code == remote.expansionVersion?.expansionCode }) {
-            preferences.expansions.delete()
-        }
-
         return preferences.expansions.asObservable()
                 .take(1)
     }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/model/ExpansionVersion.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/features/expansions/model/ExpansionVersion.kt
@@ -1,0 +1,8 @@
+package com.r0adkll.deckbuilder.arch.data.features.expansions.model
+
+
+
+data class ExpansionVersion(
+        val version: Int,
+        val expansionCode: String
+)

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/remote/plugin/CacheInvalidatePlugin.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/remote/plugin/CacheInvalidatePlugin.kt
@@ -1,0 +1,38 @@
+package com.r0adkll.deckbuilder.arch.data.remote.plugin
+
+import android.annotation.SuppressLint
+import com.r0adkll.deckbuilder.arch.data.AppPreferences
+import com.r0adkll.deckbuilder.arch.data.features.expansions.ExpansionDataSource
+import com.r0adkll.deckbuilder.arch.data.features.expansions.cache.ExpansionCache
+import com.r0adkll.deckbuilder.arch.data.remote.Remote
+import timber.log.Timber
+import javax.inject.Inject
+
+
+class CacheInvalidatePlugin @Inject constructor(
+    val expansionDataSource: ExpansionDataSource,
+    val preferences: AppPreferences
+) : RemotePlugin {
+
+    @SuppressLint("CheckResult")
+    override fun onFetchActivated(remote: Remote) {
+        // Verify cache, and invalidate if needed
+        remote.expansionVersion?.let { (versionCode, expansionCode) ->
+            Timber.d("Checking Expansion Cache (version: $versionCode, expansion: $expansionCode, prefVersion: ${preferences.expansionsVersion})")
+
+            val invalidCache = expansionDataSource.getExpansions(ExpansionCache.Source.LOCAL)
+                    .blockingFirst().none { it.code == expansionCode }
+
+            if (versionCode > preferences.expansionsVersion || invalidCache) {
+                Timber.i("Expansion Cache Invalidated, Refreshing from server (version: $versionCode, expansion: $expansionCode)")
+                expansionDataSource.refreshExpansions()
+                        .subscribe({
+                            Timber.d("Expansions refreshed, updating version(${preferences.expansionsVersion} > $versionCode)")
+                            preferences.expansionsVersion = versionCode
+                        }, {
+                            Timber.e(it, "Unable to refresh expansions, keeping old cache")
+                        })
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/data/remote/plugin/RemotePlugin.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/data/remote/plugin/RemotePlugin.kt
@@ -1,0 +1,16 @@
+package com.r0adkll.deckbuilder.arch.data.remote.plugin
+
+import com.r0adkll.deckbuilder.arch.data.remote.Remote
+
+
+/**
+ * Plugin to take action when the remote has fetched an activated updated remote config
+ * values.
+ */
+interface RemotePlugin {
+
+    /**
+     * Remote has fetched new values and activated them.
+     */
+    fun onFetchActivated(remote: Remote)
+}

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/domain/features/cards/repository/CardRepository.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/domain/features/cards/repository/CardRepository.kt
@@ -11,6 +11,7 @@ import io.reactivex.Observable
 interface CardRepository {
 
     fun getExpansions(): Observable<List<Expansion>>
+    fun refreshExpansions(): Observable<List<Expansion>>
     fun search(type: SuperType?, text: String, filter: Filter? = null): Observable<List<PokemonCard>>
     fun find(ids: List<String>): Observable<List<PokemonCard>>
 }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/RouteActivity.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/RouteActivity.kt
@@ -8,7 +8,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.r0adkll.deckbuilder.BuildConfig
 import com.r0adkll.deckbuilder.DeckApp
 import com.r0adkll.deckbuilder.arch.data.AppPreferences
-import com.r0adkll.deckbuilder.arch.data.Remote
+import com.r0adkll.deckbuilder.arch.data.remote.Remote
 import com.r0adkll.deckbuilder.arch.ui.features.home.HomeActivity
 import com.r0adkll.deckbuilder.arch.ui.features.onboarding.OnboardingActivity
 import com.r0adkll.deckbuilder.arch.ui.features.setup.SetupActivity

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browse/SetBrowserActivity.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browse/SetBrowserActivity.kt
@@ -173,7 +173,7 @@ class SetBrowserActivity : BaseActivity(), SetBrowserUi, SetBrowserUi.Intentions
             }
         }
 
-        if (!smallestWidth(TABLET_10) && tabs.tabCount <= 5) {
+        if (!smallestWidth(TABLET_10) && tabs.tabCount <= 4) {
             tabs.tabMode = TabLayout.MODE_FIXED
         }
     }

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowseFragment.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowseFragment.kt
@@ -5,6 +5,7 @@ import android.support.v7.widget.GridLayoutManager
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.StaggeredGridLayoutManager
 import android.view.*
+import com.jakewharton.rxbinding2.support.v4.widget.refreshes
 import com.r0adkll.deckbuilder.R
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion
 import com.r0adkll.deckbuilder.arch.ui.components.BaseFragment
@@ -18,11 +19,12 @@ import com.r0adkll.deckbuilder.internal.analytics.Event
 import com.r0adkll.deckbuilder.util.ScreenUtils
 import com.r0adkll.deckbuilder.util.ScreenUtils.smallestWidth
 import com.r0adkll.deckbuilder.util.extensions.toast
+import io.reactivex.Observable
 import kotlinx.android.synthetic.main.fragment_browse.*
 import javax.inject.Inject
 
 
-class BrowseFragment : BaseFragment(), BrowseUi, BrowseUi.Actions {
+class BrowseFragment : BaseFragment(), BrowseUi, BrowseUi.Actions, BrowseUi.Intentions {
 
     override var state: BrowseUi.State = BrowseUi.State.DEFAULT
 
@@ -54,6 +56,19 @@ class BrowseFragment : BaseFragment(), BrowseUi, BrowseUi.Actions {
         }
         recycler.adapter = adapter
 
+        swipeRefresh.setColorSchemeResources(
+                R.color.poketype_fire,
+                R.color.poketype_grass,
+                R.color.poketype_water,
+                R.color.poketype_electric,
+                R.color.poketype_fighting,
+                R.color.poketype_psychic,
+                R.color.poketype_steel,
+                R.color.poketype_dragon,
+                R.color.poketype_fairy,
+                R.color.poketype_dark
+        )
+
         renderer.start()
         presenter.start()
 
@@ -83,6 +98,11 @@ class BrowseFragment : BaseFragment(), BrowseUi, BrowseUi.Actions {
     }
 
 
+    override fun refreshExpansions(): Observable<Unit> {
+        return swipeRefresh.refreshes()
+    }
+
+
     override fun setExpansions(expansions: List<Expansion>) {
         adapter.setExpansions(expansions)
     }
@@ -90,6 +110,7 @@ class BrowseFragment : BaseFragment(), BrowseUi, BrowseUi.Actions {
 
     override fun showLoading(isLoading: Boolean) {
         emptyView.setLoading(isLoading)
+        swipeRefresh.isRefreshing = isLoading
     }
 
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowsePresenter.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowsePresenter.kt
@@ -13,6 +13,7 @@ import javax.inject.Inject
 
 class BrowsePresenter @Inject constructor(
         val ui: BrowseUi,
+        val intentions: BrowseUi.Intentions,
         val repository: CardRepository
 ) : Presenter() {
 
@@ -23,6 +24,8 @@ class BrowsePresenter @Inject constructor(
                 .map { Change.ExpansionsLoaded(it) as Change }
                 .startWith(Change.IsLoading as Change)
                 .onErrorReturn(handleUnknownError)
+
+        val refreshExpansions = repository.getExpansions()
 
         val merged = loadExpansions.doOnNext { Timber.d(it.logText) }
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowsePresenter.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowsePresenter.kt
@@ -25,9 +25,18 @@ class BrowsePresenter @Inject constructor(
                 .startWith(Change.IsLoading as Change)
                 .onErrorReturn(handleUnknownError)
 
-        val refreshExpansions = repository.getExpansions()
+        val refreshExpansions = intentions.refreshExpansions()
+                .flatMap { _ ->
+                    repository.refreshExpansions()
+                            .map { it.reversed() }
+                            .map { Change.ExpansionsLoaded(it) as Change }
+                            .startWith(Change.IsLoading as Change)
+                            .onErrorReturn(handleUnknownError)
+                }
 
-        val merged = loadExpansions.doOnNext { Timber.d(it.logText) }
+        val merged = loadExpansions
+                .mergeWith(refreshExpansions)
+                .doOnNext { Timber.d(it.logText) }
 
         disposables += merged.scan(ui.state, State::reduce)
                 .logState()

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowseUi.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowseUi.kt
@@ -4,6 +4,7 @@ package com.r0adkll.deckbuilder.arch.ui.features.browser
 import com.r0adkll.deckbuilder.arch.domain.features.cards.model.Expansion
 import com.r0adkll.deckbuilder.arch.ui.components.BaseActions
 import com.r0adkll.deckbuilder.arch.ui.components.renderers.StateRenderer
+import io.reactivex.Observable
 import paperparcel.PaperParcel
 import paperparcel.PaperParcelable
 
@@ -11,6 +12,12 @@ import paperparcel.PaperParcelable
 interface BrowseUi : StateRenderer<BrowseUi.State> {
 
     val state: State
+
+
+    interface Intentions {
+
+        fun refreshExpansions(): Observable<Unit>
+    }
 
 
     interface Actions : BaseActions {

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowseUi.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/BrowseUi.kt
@@ -47,6 +47,11 @@ interface BrowseUi : StateRenderer<BrowseUi.State> {
         }
 
 
+        override fun toString(): String {
+            return "State(isLoading=$isLoading, error=$error, expansions=${expansions.map { it.code }})"
+        }
+
+
         companion object {
             @JvmField val CREATOR = PaperParcelBrowseUi_State.CREATOR
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/di/BrowseModule.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/browser/di/BrowseModule.kt
@@ -18,6 +18,10 @@ class BrowseModule(val fragment: BrowseFragment) {
 
 
     @Provides @FragmentScope
+    fun provideIntentions(): BrowseUi.Intentions = fragment
+
+
+    @Provides @FragmentScope
     fun provideActions(): BrowseUi.Actions = fragment
 
 

--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/deckbuilder/DeckBuilderActivity.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/deckbuilder/DeckBuilderActivity.kt
@@ -293,6 +293,8 @@ class DeckBuilderActivity : BaseActivity(),
     override fun onBackPressed() {
         if (fragmentSwitcher != null && fragmentSwitcher!!.displayedChild == 1) {
             editOverviewClicks.accept(false)
+        } else if (slidingLayout.panelState == EXPANDED) {
+            slidingLayout.panelState = COLLAPSED
         } else if (state.isChanged) {
             Analytics.event(Event.SelectContent.Action("close_deck_editor"))
             AlertDialog.Builder(this)

--- a/app/src/main/res/layout/fragment_browse.xml
+++ b/app/src/main/res/layout/fragment_browse.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<android.support.design.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    >
 
     <com.ftinc.kit.widget.TightSwipeRefreshLayout
         android:id="@+id/swipeRefresh"
@@ -36,6 +37,9 @@
         android:layout_margin="@dimen/margin_small"
         android:src="@drawable/ic_search_white_24dp"
         app:fabSize="normal"
+        app:pressedTranslationZ="6dp"
+        app:rippleColor="@color/white30"
+        app:layout_behavior="com.r0adkll.deckbuilder.arch.ui.widgets.ScrollAwareFABBehavior"
         />
 
-</FrameLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_browse.xml
+++ b/app/src/main/res/layout/fragment_browse.xml
@@ -5,13 +5,20 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/recycler"
+    <com.ftinc.kit.widget.TightSwipeRefreshLayout
+        android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:padding="4dp"
-        android:clipToPadding="false"
-        />
+        android:layout_height="match_parent">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/recycler"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="4dp"
+            android:clipToPadding="false"
+            />
+
+    </com.ftinc.kit.widget.TightSwipeRefreshLayout>
 
     <com.ftinc.kit.widget.EmptyView
         android:id="@+id/emptyView"

--- a/app/src/main/res/layout/fragment_decks.xml
+++ b/app/src/main/res/layout/fragment_decks.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    >
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recycler"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,7 +84,7 @@
     <string name="pref_help_suggestions_title">Suggestions</string>
     <string name="pref_help_suggestions_summary">Submit any suggestions or improvements you might have</string>
     <string name="disclaimer">This application is not produced, endorsed, supported, or affiliated with Nintendo or The Pokémon Company.</string>
-    <string name="support_email_address">incoming+r0adkll/pokemon-tcg-deckbuilder@gitlab.com</string>
+    <string name="support_email_address">veedubusc+deckbox@gmail.com</string>
     <string name="developer_website_url">https://github.com/R0ADKLL</string>
     <string name="dropzone_add_message">Add Card</string>
     <string name="pref_category_account">Account</string>

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -6,6 +6,6 @@
     </entry>
     <entry>
         <key>search_proxies</key>
-        <value>{"proxies":[{"regex":"\\bn\\b","replacement":"\"N\""},{"regex":"\\b(electric)\\b(?=( +energy))","replacement":"Lightning"},{"regex":"\\b(dark)\\b(?=( +energy))","replacement":"Darkness"},{"regex":"\\b(steel)\\b(?=( +energy))","replacement":"Metal"},{"regex":"\\b( GX)\\b","replacement":"-GX"},{"regex":"\\b( EX)\\b","replacement":"-EX"},{"regex":"(Mega)(?= \\w)","replacement":"M"}]}</value>
+        <value>{"proxies":[{"regex":"\\bn\\b","replacement":"\"N\""},{"regex":"\\b(electric)\\b(?=( +energy))","replacement":"Lightning"},{"regex":"\\b(dark)\\b(?=( +energy))","replacement":"Darkness"},{"regex":"\\b(steel)\\b(?=( +energy))","replacement":"Metal"},{"regex":"\\b( GX)\\b","replacement":"-GX"},{"regex":"\\b( EX)\\b","replacement":"-EX"},{"regex":"(Mega)(?= \\w)","replacement":"M"},{"regex":"(Prism)(?! Star)","replacement":"Prism Star"}]}</value>
     </entry>
 </defaultsMap>

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <defaultsMap>
     <entry>
-        <key>latest_expansion</key>
-        <value>sm5</value>
+        <key>expansion_version</key>
+        <value>{"version":1,"expansionCode":"sm7"}</value>
     </entry>
     <entry>
         <key>search_proxies</key>

--- a/tools/remote/expansion-version.json
+++ b/tools/remote/expansion-version.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "expansionCode": "sm7"
+}

--- a/tools/remote/search-proxies.json
+++ b/tools/remote/search-proxies.json
@@ -27,6 +27,10 @@
     {
       "regex": "(Mega)(?= \\w)",
       "replacement": "M"
+    },
+    {
+      "regex": "(Prism)(?! Star)",
+      "replacement": "Prism Star"
     }
   ]
 }


### PR DESCRIPTION
Improved the expansion cache invalidation based on Remote Config by creating a plugin architecture for the Remote class that gets called whenever the remote config has been fetched & activated. 

This is a new dual-prong approach by including the latest expansion set code (i.e. sm6, sm7, etc) and a version so I can invalidate anyone's expansion cache based on a new set, or if the data changes (i.e. rotation)