### PR TITLE
fix: Ensure child is rendered before trying to draw over it

### DIFF
--- a/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/deckbuilder/adapter/line/EvolutionLineItemDecoration.kt
+++ b/app/src/main/java/com/r0adkll/deckbuilder/arch/ui/features/deckbuilder/adapter/line/EvolutionLineItemDecoration.kt
@@ -57,16 +57,19 @@ class EvolutionLineItemDecoration(
                 val state = this.adapter.getEvolutionState(index)
                 if (state.evolution == PokemonCardView.Evolution.END ||
                     state.evolution == PokemonCardView.Evolution.MIDDLE) {
-                    val child = parent.getChildAt(index)
-                    val nextChild = parent.getChildAt(index + 1)?.findViewById<PokemonCardView>(R.id.card)
+                    var child = parent.findViewHolderForItemId(adapter.getItemId(index))
+                            ?.itemView
+                    var nextChild = parent.findViewHolderForItemId(adapter.getItemId(index + 1))
+                            ?.itemView
+                            ?.findViewById<PokemonCardView>(R.id.card)
                     drawEvolutionLink(c, child, nextChild)
                 }
             }
         }
     }
 
-    private fun drawEvolutionLink(c: Canvas, child: View, nextChild: PokemonCardView?) {
-        if (nextChild != null &&
+    private fun drawEvolutionLink(c: Canvas, child: View?, nextChild: PokemonCardView?) {
+        if (child != null && nextChild != null &&
             (nextChild.evolution == PokemonCardView.Evolution.START ||
                 nextChild.evolution == PokemonCardView.Evolution.MIDDLE)) {
             // Render Link


### PR DESCRIPTION
This applies the fix from #136 to the "v2 updates" branch since that seems to be the published version.

Description from that PR:
Fixes #125 

This ensures that we don't have a null child (thus, it is rendered) before trying to draw over it. I had to move away from `parent.getChildAt` because the index can be outside of the page of the underlying RecyclerView. Even if I checked for a null child, the evolution decoration line wouldn't render by using that function.

I found this information at https://stackoverflow.com/a/67710269

> When there is more than one page of data in your recycler view and you're using getChildAt() method, it will throw a null pointer exception. This is because when the position is greater than the number of visible items on the display, getChildAt() won't work as it can only get to the view that is displayed on the screen.
>> 
Therefore, use recyclerView.layoutManager?.findViewByPosition(position) to get the view at the given position.