### PR TITLE
chore: Update Java to 11

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,12 +57,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility 11
+        targetCompatibility 11
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
         freeCompilerArgs = ["-Xallow-result-return-type"]
     }
 


### PR DESCRIPTION
This updates the project to Java 11, which is the default version available in Android Studio chipmunk. I couldn't get this project to build successfully in Android Studio with Java 1.8.